### PR TITLE
CRUD facade and test

### DIFF
--- a/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/slots/GroupDAO.java
+++ b/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/slots/GroupDAO.java
@@ -164,6 +164,7 @@ public class GroupDAO implements DAO<Group> {
 
     /**
      * Save into join table group_slot, considering both are already saved in their respective tables
+     * Should only be used by SlotDAO
      *
      * @param slotId  Slot entity id to save
      * @param groupId Group entity id to save

--- a/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/users/AdminDAO.java
+++ b/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/users/AdminDAO.java
@@ -142,7 +142,7 @@ public class AdminDAO implements DAO<Admin> {
         } catch (SQLException e){
             log.error(e.getMessage());
         }
-        log.error("Not supposed to be used");
+        log.error("Not supposed to be used,Saving without password");
     }
 
     /**

--- a/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAO.java
+++ b/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAO.java
@@ -32,10 +32,10 @@ public class ProfessorDAO implements DAO<Professor> {
     private static final String GET_PROFESSOR_AUTH = "SELECT * FROM PROFESSORS WHERE EMAIL=? AND PASSWORD=?";
 
 
-    private ProfessorDAO () {
+    private ProfessorDAO() {
     }
 
-    public static ProfessorDAO of () {
+    public static ProfessorDAO of() {
         return new ProfessorDAO();
     }
 
@@ -46,11 +46,11 @@ public class ProfessorDAO implements DAO<Professor> {
      * @return May return one Professor
      */
     @Override
-    public Optional<Professor> get ( long id ) {
+    public Optional<Professor> get(long id) {
         Optional<Professor> fetchedProfessor = Optional.empty();
         try (Connection conn = Datasource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(GET)
-        ){
+        ) {
             stmt.setLong(1, id);
             ResultSet resultSet = stmt.executeQuery();
             if (resultSet.next()) {
@@ -63,7 +63,7 @@ public class ProfessorDAO implements DAO<Professor> {
                 );
                 fetchedProfessor.get().setId(resultSet.getLong("ID"));
             }
-        }catch (SQLException | IdException e){
+        } catch (SQLException | IdException e) {
             log.error(e.getMessage());
         }
         return fetchedProfessor;
@@ -71,7 +71,8 @@ public class ProfessorDAO implements DAO<Professor> {
 
     /**
      * Getter for one professor, using email and password
-     * @param email Unique email of the corresponding professor
+     *
+     * @param email    Unique email of the corresponding professor
      * @param password Password of the Professor account
      * @return Professor Entity, or null if not found
      * @throws SQLException
@@ -81,12 +82,12 @@ public class ProfessorDAO implements DAO<Professor> {
 
         try (Connection conn = Datasource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(GET_PROFESSOR_AUTH)
-        ){
+        ) {
             stmt.setString(1, email);
             stmt.setString(2, password);
             ResultSet rs = stmt.executeQuery();
 
-            if (rs.next()){
+            if (rs.next()) {
                 result = Professor.of(
                         rs.getString("NAME"),
                         rs.getString("FNAME"),
@@ -95,7 +96,7 @@ public class ProfessorDAO implements DAO<Professor> {
                 );
                 result.setId(rs.getLong("ID"));
             }
-        } catch (SQLException | IdException e){
+        } catch (SQLException | IdException e) {
             log.error(e.getMessage());
         }
 
@@ -104,6 +105,7 @@ public class ProfessorDAO implements DAO<Professor> {
 
     /**
      * Getter for all Professor
+     *
      * @return List of all Professor
      */
     @Override
@@ -111,18 +113,18 @@ public class ProfessorDAO implements DAO<Professor> {
         List<Professor> professorList = new ArrayList<>();
         try (Connection conn = Datasource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(GET_ALL)
-        ){
+        ) {
             ResultSet rs = stmt.executeQuery();
             while (rs.next()) {
                 Professor fetchedProfessor = Professor.of(
-                                rs.getString("NAME"),
-                                rs.getString("FNAME"),
-                                rs.getString("EMAIL"),
-                                rs.getString("TITLE"));
+                        rs.getString("NAME"),
+                        rs.getString("FNAME"),
+                        rs.getString("EMAIL"),
+                        rs.getString("TITLE"));
                 fetchedProfessor.setId(rs.getLong("ID"));
                 professorList.add(fetchedProfessor);
             }
-        } catch (SQLException | IdException e){
+        } catch (SQLException | IdException e) {
             log.error(e.getMessage());
         }
         return professorList;
@@ -130,18 +132,19 @@ public class ProfessorDAO implements DAO<Professor> {
 
     /**
      * Get all professor associated to a Slot (via table professor_slot)
+     *
      * @return List of Professor entity
      * @throws SQLException
      */
     public List<Professor> getAllProfessorSlot() throws SQLException {
         List<Professor> professorList = new ArrayList<>();
         try (Connection conn = Datasource.getConnection();
-            PreparedStatement stmt = conn.prepareStatement(GET_ALL_PROFESSOR_SLOT_STMT)
-        ){
+             PreparedStatement stmt = conn.prepareStatement(GET_ALL_PROFESSOR_SLOT_STMT)
+        ) {
             ResultSet rs = stmt.executeQuery();
             while (rs.next())
-                professorList.add( get( rs.getLong("id_professor") ).get() );
-        } catch (SQLException e){
+                professorList.add(get(rs.getLong("id_professor")).get());
+        } catch (SQLException e) {
             log.error(e.getMessage());
             throw e;
         }
@@ -154,42 +157,45 @@ public class ProfessorDAO implements DAO<Professor> {
      * <!>SHOULD ONLY BE USED FOR TEST</!>
      * this methode save a User without a password
      * please use save(Professor s,String password)
+     *
      * @param professor Professor object to save
      */
     @Override
     public void save(Professor professor) {
-        try(Connection conn = Datasource.getConnection();
-            PreparedStatement stmt = conn.prepareStatement(SAVE)
-        ){
+        try (Connection conn = Datasource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SAVE)
+        ) {
             stmt.setString(1, professor.getName());
             stmt.setString(2, professor.getFname());
             stmt.setString(3, professor.getEmail());
             stmt.setString(4, "NO_PASSWORD");
             stmt.setString(5, professor.getTitle());
             stmt.executeUpdate();
-        } catch (SQLException e){
+        } catch (SQLException e) {
             log.error(e.getMessage());
         }
-        log.error("Not supposed to be used");
+        log.error("Not supposed to be used,Saving without password");
     }
 
     /**
      * Save Professor t to Database and add the ID generate by the database
      * to professor, if the professor exist it will only update the ID
+     *
      * @param professor Professor object to save
-     * @param password password to save inside the database
+     * @param password  password to save inside the database
      */
     public void save(Professor professor, String password) {
-        try(Connection conn = Datasource.getConnection();
-            PreparedStatement stmt = conn.prepareStatement(SAVE, RETURN_GENERATED_KEYS)
-        ){
+        try (Connection conn = Datasource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SAVE, RETURN_GENERATED_KEYS)
+        ) {
             stmt.setString(1, professor.getName());
             stmt.setString(2, professor.getFname());
             stmt.setString(3, professor.getEmail());
             stmt.setString(4, password);
             stmt.setString(5, professor.getTitle());
             stmt.executeUpdate();
-            ResultSet id_set = stmt.getGeneratedKeys(); id_set.next();
+            ResultSet id_set = stmt.getGeneratedKeys();
+            id_set.next();
             professor.setId(id_set.getLong(1));
         } catch (SQLException | IdException e) {
             log.error(e.getMessage());
@@ -198,12 +204,13 @@ public class ProfessorDAO implements DAO<Professor> {
 
     /**
      * Save into join table professor_slot, considering both are already saved in their respective tables
+     * Should only be used by SlotDAO
      *
      * @param slotId           Slot entity id to save
      * @param professorIdArray Professor entity id to save
      * @throws SQLException thrown Exception in case of Errors, especially if one of the two ids doesn't exist in entity tables
      */
-    public void save ( long slotId, long[] professorIdArray ) throws SQLException {
+    public void save(long slotId, long[] professorIdArray) throws SQLException {
         Connection conn = Datasource.getConnection();
         try (conn;
              PreparedStatement stmt = conn.prepareStatement(SAVE_SLOT_STMT)
@@ -218,21 +225,21 @@ public class ProfessorDAO implements DAO<Professor> {
     /**
      * Update the data of Professor in the database, without modifying the object professor,
      * to get the new professor use <code>updateAndGet</code>
+     *
      * @param professor a Professor
      */
     @Override
     public Professor update(Professor professor) throws IdException {
         try (Connection conn = Datasource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(UPDATE)
-        ){
-            stmt.setString(1,professor.getName());
+        ) {
+            stmt.setString(1, professor.getName());
             stmt.setString(2, professor.getFname());
-            stmt.setString(3,professor.getEmail());
-            stmt.setString(4,professor.getTitle());
-            stmt.setLong(5,professor.getId());
+            stmt.setString(3, professor.getEmail());
+            stmt.setString(4, professor.getTitle());
+            stmt.setLong(5, professor.getId());
             stmt.executeUpdate();
-        }
-        catch (SQLException e){
+        } catch (SQLException e) {
             log.error(e.getMessage());
         }
         return professor;
@@ -240,19 +247,20 @@ public class ProfessorDAO implements DAO<Professor> {
 
 
     /**
-     *Take the Id of a Slot and return every professors related from this slot
+     * Take the Id of a Slot and return every professors related from this slot
      * by using the professor_slot table in the database
+     *
      * @param slotId an Id of a sot
      * @return List of Professor
      */
-    public List<Professor> getProfessorOfSlots(long slotId){
+    public List<Professor> getProfessorOfSlots(long slotId) {
         List<Professor> ProfessorsOfSlot = new ArrayList<>();
         try (Connection conn = Datasource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(GET_PROFESSOR_OF_SLOT)
-        ){
-            stmt.setLong(1,slotId);
+        ) {
+            stmt.setLong(1, slotId);
             stmt.executeQuery();
-            ResultSet rs =stmt.getResultSet();
+            ResultSet rs = stmt.getResultSet();
             while (rs.next()) {
                 ProfessorsOfSlot.add(get(rs.getLong(1)).get());
             }
@@ -265,17 +273,17 @@ public class ProfessorDAO implements DAO<Professor> {
 
     /**
      * Delete Professor from Database
+     *
      * @param professor Professor to be deleted from the database
      */
     @Override
     public void delete(Professor professor) {
         try (Connection conn = Datasource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(DELETE)
-        ){
+        ) {
             stmt.setLong(1, professor.getId());
             stmt.executeUpdate();
-        }
-        catch (SQLException e){
+        } catch (SQLException e) {
             log.error(e.getMessage());
         }
     }

--- a/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/users/StudentDAO.java
+++ b/edtLHD/src/main/java/fr/univtln/lhd/model/entities/dao/users/StudentDAO.java
@@ -166,7 +166,7 @@ public class StudentDAO implements DAO<Student> {
         } catch (SQLException e){
             log.error(e.getMessage());
         }
-        log.error("Not supposed to be used");
+        log.error("Not supposed to be used,Saving without password");
     }
 
     /**
@@ -201,17 +201,13 @@ public class StudentDAO implements DAO<Student> {
      */
     private void saveStudentGroup(Student student) throws SQLException {
         List<Group> groups = student.getStudentGroup();
-
         if (groups == null) return;
-
         GroupDAO groupDAO = GroupDAO.getInstance();
-
         try (Connection conn = Datasource.getConnection();
              PreparedStatement stmt = conn.prepareStatement(SAVE_GROUP)
         ) {
             for (Group group : groups){
-                groupDAO.save(group);
-
+                if (group.getId()<0) groupDAO.save(group);
                 stmt.setLong(1, group.getId());
                 stmt.setLong(2, student.getId());
                 stmt.executeUpdate();

--- a/edtLHD/src/test/java/fr/univtln/lhd/facade/ScheduleTest.java
+++ b/edtLHD/src/test/java/fr/univtln/lhd/facade/ScheduleTest.java
@@ -1,0 +1,290 @@
+package fr.univtln.lhd.facade;
+
+import fr.univtln.lhd.model.entities.dao.slots.ClassroomDAO;
+import fr.univtln.lhd.model.entities.dao.slots.GroupDAO;
+import fr.univtln.lhd.model.entities.dao.slots.SlotDAO;
+import fr.univtln.lhd.model.entities.dao.slots.SubjectDAO;
+import fr.univtln.lhd.model.entities.dao.users.AdminDAO;
+import fr.univtln.lhd.model.entities.dao.users.ProfessorDAO;
+import fr.univtln.lhd.model.entities.dao.users.StudentDAO;
+import fr.univtln.lhd.model.entities.slots.Classroom;
+import fr.univtln.lhd.model.entities.slots.Group;
+import fr.univtln.lhd.model.entities.slots.Slot;
+import fr.univtln.lhd.model.entities.slots.Subject;
+import fr.univtln.lhd.model.entities.users.Admin;
+import fr.univtln.lhd.model.entities.users.Professor;
+import fr.univtln.lhd.model.entities.users.Student;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.threeten.extra.Interval;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.*;
+
+@Slf4j
+class ScheduleTest {
+
+
+    private Map mapOfSlot;
+
+    @BeforeEach
+    public void GetNewRealSlot() throws SQLException {
+        mapOfSlot = new HashMap<>();
+        Professor professorTest = Professor.of("test", "test", "ProfessorTest@test.fr"+Math.random(), "testTitle");
+        ProfessorDAO professorDAO = ProfessorDAO.of();
+        professorDAO.save(professorTest,"test");
+        mapOfSlot.put("Professor", professorTest);
+        Subject subjectTest = Subject.getInstance("testSubject"+Math.random(), 42);
+        SubjectDAO subjectDAO = SubjectDAO.getInstance();
+        subjectDAO.save(subjectTest);
+        mapOfSlot.put("Subject", subjectTest);
+        Group groupTest = Group.getInstance("GroupTest"+Math.random());
+        GroupDAO groupDAO = GroupDAO.getInstance();
+        groupDAO.save(groupTest);
+        mapOfSlot.put("Group", groupTest);
+        Student studentTest = Student.of("test", "test", "StudentTest@test.fr"+Math.random());
+        StudentDAO studentDAO = StudentDAO.getInstance();
+        studentTest.add(groupTest);
+        studentDAO.save(studentTest, "test");
+        mapOfSlot.put("Student", studentTest);
+        Classroom classroomTest = Classroom.getInstance("ClassTest"+Math.random());
+        ClassroomDAO classroomDAO = ClassroomDAO.getInstance();
+        classroomDAO.save(classroomTest);
+        mapOfSlot.put("Classroom", classroomTest);
+        List<Group> lgroup = new ArrayList<>();
+        lgroup.add(groupTest);
+        List<Professor> lprofessor = new ArrayList<>();
+        lprofessor.add(professorTest);
+        Interval intervalTest = Interval.of(Instant.now(), Duration.ofHours(1));
+        Slot slotTest = Slot.getInstance(Slot.SlotType.CM, classroomTest, subjectTest, lgroup, lprofessor,intervalTest );
+        mapOfSlot.put("Type",Slot.SlotType.CM);
+        SlotDAO slotdao = SlotDAO.getInstance();
+        slotdao.save(slotTest);
+        mapOfSlot.put("Slot", slotTest);
+    }
+
+    @AfterEach
+    public void cleanDbFromRealSlot(){
+        try {
+        ProfessorDAO professorDAO = ProfessorDAO.of();
+        professorDAO.delete((Professor) mapOfSlot.get("Professor"));
+        SubjectDAO subjectDAO = SubjectDAO.getInstance();
+        subjectDAO.delete((Subject) mapOfSlot.get("Subject"));
+        GroupDAO groupDAO = GroupDAO.getInstance();
+        groupDAO.delete((Group) mapOfSlot.get("Group"));
+        StudentDAO studentDAO = StudentDAO.getInstance();
+        studentDAO.delete((Student) mapOfSlot.get("Student"));
+        ClassroomDAO classroomDAO = ClassroomDAO.getInstance();
+        classroomDAO.delete((Classroom) mapOfSlot.get("Classroom"));
+        SlotDAO slotdao = SlotDAO.getInstance();
+        slotdao.delete((Slot) mapOfSlot.get("Slot"));
+        }
+        catch (SQLException e){
+            log.error("did not clean after test:"+e.getMessage());
+        }
+    }
+
+
+    @Test
+    void getScheduleOfStudent() throws SQLException {
+        Slot slotOfMap = (Slot) mapOfSlot.get("Slot");
+        Student studentOfMap = (Student) mapOfSlot.get("Student");
+        List<Slot> scheduleFetch = Schedule.getSchedule(studentOfMap,slotOfMap.getTimeRange());
+        Assertions.assertEquals(slotOfMap.getId(),scheduleFetch.get(0).getId());
+    }
+
+    @Test
+    void getScheduleOfStudentWithLocalDate() throws SQLException {
+        Slot slotOfMap = (Slot) mapOfSlot.get("Slot");
+        Student studentOfMap = (Student) mapOfSlot.get("Student");
+        LocalDate today = LocalDate.now();
+        LocalDate tomorow = LocalDate.now().plusDays(1);
+        List<Slot> scheduleFetch = Schedule.getSchedule(studentOfMap,today,tomorow);
+        Assertions.assertEquals(slotOfMap.getId(),scheduleFetch.get(0).getId());
+    }
+
+    @Test
+    void getScheduleOfNonePersistedStudentWithLocalDate() throws SQLException {
+        Slot slotOfMap = (Slot) mapOfSlot.get("Slot");
+        Student student = Student.of("Does","not","Exist");
+        LocalDate today = LocalDate.now();
+        LocalDate tomorow = LocalDate.now().plusDays(1);
+        List<Slot> scheduleFetch = Schedule.getSchedule(student,today,tomorow);
+        Assertions.assertEquals(0,scheduleFetch.size());
+    }
+
+    @Test
+    void getScheduleOfGroupWithLocalDate() throws SQLException {
+        Slot slotOfMap = (Slot) mapOfSlot.get("Slot");
+        Group grouOfMap = (Group) mapOfSlot.get("Group");
+        LocalDate today = LocalDate.now();
+        LocalDate tomorow = LocalDate.now().plusDays(1);
+        List<Slot> scheduleFetch = Schedule.getSchedule(grouOfMap,today,tomorow);
+        Assertions.assertEquals(slotOfMap.getId(),scheduleFetch.get(0).getId());
+    }
+
+    @Test
+    void getScheduleOfNonePersistedGroupWithLocalDate() throws SQLException {
+        Slot slotOfMap = (Slot) mapOfSlot.get("Slot");
+        Group group = Group.getInstance("Noteexiste");
+        LocalDate today = LocalDate.now();
+        LocalDate tomorow = LocalDate.now().plusDays(1);
+        List<Slot> scheduleFetch = Schedule.getSchedule(group,today,tomorow);
+        Assertions.assertEquals(0,scheduleFetch.size());
+    }
+
+    @Test
+    void getScheduleOfGroup() throws SQLException{
+        Slot slotOfMap = (Slot) mapOfSlot.get("Slot");
+        Group groupOfMap = (Group) mapOfSlot.get("Group");
+        List<Slot> scheduleFetch = Schedule.getSchedule(groupOfMap,slotOfMap.getTimeRange());
+        Assertions.assertEquals(slotOfMap.getId(),scheduleFetch.get(0).getId());
+    }
+
+    @Test
+    void shouldReturnTheTestStudent() throws SQLException {
+        String email = "StudentTest@test.fr"+Math.random();
+        Student studentTestAuth = Student.of("test", "test", email);
+        StudentDAO studentDAO = StudentDAO.getInstance();
+        studentDAO.save(studentTestAuth, "test");
+        Optional<Student> resultGetter = Schedule.getStudentFromAuth(email, "test");
+        Assertions.assertEquals(studentTestAuth, resultGetter.get());
+        studentDAO.delete(studentTestAuth);
+    }
+
+    @Test
+    void getProfessorFromAuth() {
+        String email = "professorTest@test.fr"+Math.random();
+        Professor professorTestAuth = Professor.of("test", "test", email, "testTitle");
+        ProfessorDAO DAO = ProfessorDAO.of();
+        DAO.save(professorTestAuth, "test");
+        Optional<Professor> resultGetter = Schedule.getProfessorFromAuth(email, "test");
+        Assertions.assertEquals(professorTestAuth, resultGetter.get());
+        DAO.delete(professorTestAuth);
+    }
+
+    @Test
+    void shouldNotAddSlotToDatabase(){
+        List<Group> groups= new ArrayList<Group>();
+        groups.add(Group.getInstance("groupe"));
+        List<Professor> professors= new ArrayList<Professor>();
+        professors.add(Professor.of("n","f","m"+Math.random(),"t"));
+        Slot newSlot = Slot.getInstance(Slot.SlotType.CM,
+                Classroom.getInstance("ClasssUnitTest"),
+                Subject.getInstance("UnitTestaddSlotFacade",42),
+                groups,
+                professors,
+                Interval.of(Instant.now(), Duration.ofHours(1)) );
+        Assertions.assertTrue(Schedule.addToSchedule(newSlot));
+    }
+    @Test
+    void shouldAddSlotToDatabase() throws SQLException {
+        List<Group> groups= new ArrayList<Group>();
+        groups.add((Group) mapOfSlot.get("Group"));
+        List<Professor> professors= new ArrayList<Professor>();
+        professors.add((Professor) mapOfSlot.get("Professor"));
+        Slot newSlot = Slot.getInstance(Slot.SlotType.CM,
+                (Classroom)mapOfSlot.get("Classroom"),
+                (Subject)mapOfSlot.get("Subject"),
+                groups,
+                professors,
+                Interval.of(Instant.now().plusSeconds(3600), Duration.ofHours(1)) );
+        Schedule.addToSchedule(newSlot);
+        SlotDAO dao = SlotDAO.getInstance();
+        Optional<Slot> slotDb =null;
+        try {
+            slotDb = dao.get(newSlot.getId());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        Assertions.assertEquals(slotDb.get().getId(),newSlot.getId());
+        dao.delete(newSlot);
+    }
+
+    @Test
+    void shouldDeleteSlotFromDB() throws SQLException {
+        List<Group> groups= new ArrayList<Group>();
+        groups.add((Group) mapOfSlot.get("Group"));
+        List<Professor> professors= new ArrayList<Professor>();
+        professors.add((Professor) mapOfSlot.get("Professor"));
+        Slot newSlot = Slot.getInstance(Slot.SlotType.CM,
+                (Classroom)mapOfSlot.get("Classroom"),
+                (Subject)mapOfSlot.get("Subject"),
+                groups,
+                professors,
+                Interval.of(Instant.now().plusSeconds(3600), Duration.ofHours(1)) );
+        SlotDAO dao = SlotDAO.getInstance();
+        dao.save(newSlot);
+        int oldSize = dao.getAll().size();
+        Schedule.deleteInSchedule(newSlot);
+        int newSize = dao.getAll().size();
+        Assertions.assertEquals(oldSize-1,newSize);
+    }
+
+
+    @Test
+    void shouldUpdateSlotInDB() throws SQLException {
+        List<Group> groups= new ArrayList<Group>();
+        groups.add((Group) mapOfSlot.get("Group"));
+        List<Professor> professors= new ArrayList<Professor>();
+        professors.add((Professor) mapOfSlot.get("Professor"));
+        Slot newSlot = Slot.getInstance(Slot.SlotType.TD,
+                (Classroom)mapOfSlot.get("Classroom"),
+                (Subject)mapOfSlot.get("Subject"),
+                groups,
+                professors,
+                Interval.of(Instant.now().plusSeconds(3600), Duration.ofHours(1)) );
+        SlotDAO dao = SlotDAO.getInstance();
+        Schedule.updateInSchedule((Slot) mapOfSlot.get("Slot"),newSlot);
+        Optional<Slot> slotfromDb = dao.get(((Slot) mapOfSlot.get("Slot")).getId());
+        Assertions.assertNotEquals(slotfromDb.get().getType(),mapOfSlot.get("Type"));
+    }
+
+    @Test
+    void shouldNotUpdateSlotInDB() throws SQLException {
+        List<Group> groups= new ArrayList<Group>();
+        groups.add((Group) mapOfSlot.get("Group"));
+        List<Professor> professors= new ArrayList<Professor>();
+        professors.add((Professor) mapOfSlot.get("Professor"));
+        Slot newSlot = Slot.getInstance(Slot.SlotType.TD,
+                (Classroom)mapOfSlot.get("Classroom"),
+                (Subject)mapOfSlot.get("Subject"),
+                groups,
+                professors,
+                Interval.of(Instant.now().plusSeconds(3600), Duration.ofHours(1)) );
+        Assertions.assertTrue(Schedule.updateInSchedule(newSlot,newSlot));
+    }
+
+    @Test
+    void shouldNotDeleteSlotFromDB() throws SQLException {
+        List<Group> groups= new ArrayList<Group>();
+        groups.add((Group) mapOfSlot.get("Group"));
+        List<Professor> professors= new ArrayList<Professor>();
+        professors.add((Professor) mapOfSlot.get("Professor"));
+        Slot newSlot = Slot.getInstance(Slot.SlotType.CM,
+                (Classroom)mapOfSlot.get("Classroom"),
+                (Subject)mapOfSlot.get("Subject"),
+                groups,
+                professors,
+                Interval.of(Instant.now().plusSeconds(3600), Duration.ofHours(1)) );
+        SlotDAO dao = SlotDAO.getInstance();
+        int oldSize = dao.getAll().size();
+        Assertions.assertTrue(Schedule.deleteInSchedule(newSlot));
+    }
+
+    @Test
+    void getAdminFromAuth() {
+        String email = "adminTest@test.fr"+Math.random();
+        Admin adminTestAuth = Admin.of("test", "test", email, "testFaculty");
+        AdminDAO studentDAO = AdminDAO.of();
+        studentDAO.save(adminTestAuth, "test");
+        Optional<Admin> resultGetter = Schedule.getAdminFromAuth(email, "test");
+        Assertions.assertEquals(adminTestAuth, resultGetter.get());
+        studentDAO.delete(adminTestAuth);
+    }
+
+
+}


### PR DESCRIPTION
As of now, the facade only let to *Read*, but to achieve the next US(#20 #21 #22 #23) we need to be able
to easily manipulate the database through the facade, furthermore with #62 we should implement rigorous 
testing.
 - [x] ``addToSchedule(Slot)``
 this method assume that the necessary attribute are persisted. I did a version
that automatically persisted the attribute but I think it wasn't the right way.
therefore in the future we need method to add (`Classroom, User, Professor, Group, Subject`) 
 - [x] ``DeteleInSchedule(Slot)``
 - [x] ``UpdateInSchedule(OldSlot,NewSlot)``
 Same comment that for add but I am not certain , maybe if OldSlot doesn't exist we could save it ?
 - [x] *Test* 
 80% I need to test the exception in the future, but I believe we need to completely change our exception.

Their is some change, in the DAO it's mainly the linter but their is bug fix concerning the attribution of ID
on a StudentGroup