### PR TITLE
Test coherence fix

### DIFF
--- a/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/slots/ClassroomDAOTest.java
+++ b/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/slots/ClassroomDAOTest.java
@@ -2,7 +2,9 @@ package fr.univtln.lhd.model.entities.dao.slots;
 
 import fr.univtln.lhd.exceptions.IdException;
 import fr.univtln.lhd.model.entities.slots.Classroom;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
@@ -10,6 +12,8 @@ import java.sql.SQLException;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ClassroomDAOTest {
+
+    private Classroom classroom;
 
     public ClassroomDAO getDAO() {
         return ClassroomDAO.getInstance();
@@ -19,8 +23,24 @@ class ClassroomDAOTest {
         return Classroom.getInstance("Random"+Math.random());
     }
 
-    private Classroom getTheTestClassroom(){
-        return Classroom.getInstance("TestClassroom");
+    @BeforeEach
+    public void initializeTestEnvironment() {
+        classroom = Classroom.getInstance("ClassTestingOnly");
+
+        try {
+            getDAO().save(classroom);
+        } catch (SQLException e){
+            throw new AssertionError();
+        }
+    }
+
+    @AfterEach
+    public void deleteTestEnvironment() {
+        try {
+            getDAO().delete(classroom);
+        } catch (SQLException e){
+            throw new AssertionError();
+        }
     }
 
     @Test
@@ -46,11 +66,9 @@ class ClassroomDAOTest {
     @Test
     void updateClassroom() {
         ClassroomDAO dao = getDAO();
-        Classroom classroom = getRandomNewClassroom();
         Classroom classroom1 = Classroom.getInstance(classroom.getName()+"1");
 
         try {
-            dao.save(classroom);
             classroom1.setId(classroom.getId());
             dao.update(classroom1);
             assertEquals(dao.get(classroom.getId()).orElseThrow(SQLException::new), classroom1);
@@ -62,7 +80,6 @@ class ClassroomDAOTest {
     @Test
     void addSameClassroom(){
         ClassroomDAO dao = getDAO();
-        Classroom classroom = getTheTestClassroom();
         final String defaultMsg = "Done Save Without Error";
 
         SQLException thrown = assertThrows(

--- a/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/slots/SubjectDAOTest.java
+++ b/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/slots/SubjectDAOTest.java
@@ -4,6 +4,8 @@ import fr.univtln.lhd.exceptions.IdException;
 import fr.univtln.lhd.model.entities.slots.Subject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,12 +41,16 @@ class SubjectDAOTest {
     @Test
     void updateASubject() throws IdException {
         SubjectDAO dao = getDAO();
-        Optional<Subject> subject = dao.get(1);
-        System.out.println("tt="+subject.orElseThrow(AssertionError::new));
-        Subject subject1 = Subject.getInstance(subject.get().getName()+"1",subject.get().getHourCountMax()+1);
-        subject1.setId(1);
-        System.out.println(subject1);
+        Subject subject = getSubject();
+
+        dao.save(subject);
+        Subject subject1 = Subject.getInstance(subject.getName()+"1",subject.getHourCountMax()+1);
+        subject1.setId(subject.getId());
         dao.update(subject1);
-        assertEquals(subject1,dao.get(subject.get().getId()).orElseThrow(AssertionError::new));
+
+        Subject newUpdatedSubject = dao.get(subject.getId()).orElseThrow(AssertionError::new);
+        assertEquals(subject1, newUpdatedSubject);
+
+        dao.delete(subject);
     }
 }

--- a/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAOTest.java
+++ b/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAOTest.java
@@ -1,21 +1,13 @@
 package fr.univtln.lhd.model.entities.dao.users;
 
 import fr.univtln.lhd.exceptions.IdException;
-import fr.univtln.lhd.model.entities.dao.slots.ClassroomDAO;
-import fr.univtln.lhd.model.entities.dao.slots.SlotDAO;
-import fr.univtln.lhd.model.entities.dao.slots.SubjectDAO;
-import fr.univtln.lhd.model.entities.slots.Classroom;
-import fr.univtln.lhd.model.entities.slots.Slot;
-import fr.univtln.lhd.model.entities.slots.Subject;
 import fr.univtln.lhd.model.entities.users.Professor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.*;
-import org.threeten.extra.Interval;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,59 +15,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ProfessorDAOTest {
     public static final ProfessorDAO dao = ProfessorDAO.of();
 
-    private Professor professor1;
-    private Professor professor2;
-
-    private Classroom classroom;
-    private Subject subject;
-
-    private Professor getRandomNewProfessor () {
-        return Professor.of("UnitTest", "UnitTestFirstName",
-                "UnitTestName.Firstname" + Math.random() + "@email.com", "REseracher");
+    private Professor getRandomNewProfessor(){
+        return Professor.of("UnitTest","UnitTestFirstName",
+                "UnitTestName.Firstname"+Math.random()+"@email.com","REseracher");
     }
 
-    @BeforeEach
-    public void initializeTestEnvironment () {
-        professor1 = Professor.of("name1", "fname1", "prof1TESTING@mail.com", "test");
-        professor2 = Professor.of("name2", "fname2", "prof2TESTING@mail.com", "test");
-        dao.save(professor1, "testingOnly");
-        dao.save(professor2, "testingOnly");
-    }
-
-    private void initSlotData () {
-        classroom = Classroom.getInstance("ClassroomTESTING");
-        subject = Subject.getInstance("SubjectTESTING", 100);
-
-        try {
-            ClassroomDAO.getInstance().save(classroom);
-            SubjectDAO.getInstance().save(subject);
-        } catch (SQLException e) {
-            throw new AssertionError();
-        }
-    }
-
-    @AfterEach
-    public void deleteTestEnvironment () {
-        dao.delete(professor1);
-        dao.delete(professor2);
-    }
-
-    private void deleteSlotData () {
-        try {
-            ClassroomDAO.getInstance().delete(classroom);
-            SubjectDAO.getInstance().delete(subject);
-        } catch (SQLException e) {
-            throw new AssertionError();
-        }
+    
+    private Professor getTheTestProfessor(){
+        return Professor.of("TheTestProfessor","UnitTestFirstName",
+                "UnitTestName.Firstname@email.com","Researcher");
     }
 
     @Test
-    void CreateADAO () {
+    void CreateADAO(){
         Assertions.assertNotNull(dao);
     }
 
     @Test
-    void addNewProfessor () {
+    void addNewProfessor(){
         Professor professor = getRandomNewProfessor();
         int oldsize = dao.getAll().size();
         dao.save(professor,"1234");
@@ -86,9 +43,11 @@ class ProfessorDAOTest {
     @Test
     @Disabled("Causes the CI to fail")
     void getProfessorFromAuthTest(){
+        Professor professor = getTheTestProfessor();
+
         try {
-            Professor authGetterProfessor = dao.get(professor1.getEmail(), "testingOnly").orElse(null);
-            assertEquals(professor1, authGetterProfessor);
+            Professor authGetterProfessor = dao.get(professor.getEmail(), "1234").orElse(null);
+            assertEquals(professor, authGetterProfessor);
         }catch (SQLException e){
             log.error(e.getMessage());
             throw new AssertionError();
@@ -97,49 +56,27 @@ class ProfessorDAOTest {
 
     @Test
     void updateAprofessor() throws IdException {
-        Professor professor3 = Professor.of(professor1.getName() + "1", professor1.getFname() + "1", professor1.getEmail() + "1", professor1.getTitle());
-        professor3.setId(professor1.getId());
-        dao.update(professor3);
-        Professor updatedProfessor = dao.get(professor3.getId()).orElseThrow(AssertionError::new);
-        assertEquals(updatedProfessor, professor3);
+        Professor professor = getRandomNewProfessor();
+        Professor professor1 = Professor.of(professor.getName()+"1",professor.getFname()+"1",professor.getEmail()+"1", professor.getTitle());
+        dao.save(professor,"1234");
+        professor1.setId(professor.getId());
+        dao.update(professor1);
+        assertEquals(dao.get(professor.getId()).orElseThrow(AssertionError::new),professor1);
     }
 
     @Test//Not realy a test must be change when slot is implemented TODO
-    void getProfessorOfASlot() {
-        SlotDAO slotDAO = SlotDAO.getInstance();
-
-        initSlotData();
-
-        Slot slot = Slot.getInstance(
-                Slot.SlotType.TP,
-                classroom,
-                subject,
-                new ArrayList<>(),
-                List.of(professor1, professor2),
-                Interval.of(Instant.ofEpochSecond((long) (10000 + Math.random())), Instant.ofEpochSecond((long) (1000000 + Math.random())))
-        );
-
-        try {
-            slotDAO.save(slot);
-            List<Professor> professorsOfSlot = dao.getProfessorOfSlots(slot.getId());
-            assertEquals(professorsOfSlot, slot.getProfessors());
-            slotDAO.delete(slot);
-        } catch (SQLException e) {
-            throw new AssertionError();
-        }
-
-        deleteSlotData();
+    void getProfessorOfASlot(){
+        System.out.println(dao.getProfessorOfSlots(3));
+        assertEquals(2,1+1);
     }
 
     @Test
-    void addSameProfessor() {
-        final String defaultMsg = "Done Save Without Error";
-
-        int oldSize = dao.getAll().size();
-        dao.save(professor1, "testingOnly");
-        int newSize = dao.getAll().size();
-
-        assertEquals(oldSize, newSize);
+    void addSameProfessor(){
+        Professor professor = getTheTestProfessor();
+        dao.save(professor,"1234");
+        int oldsize = dao.getAll().size();
+        dao.save(professor,"1234");
+        assertEquals(oldsize,dao.getAll().size());
     }
 
 
@@ -151,4 +88,5 @@ class ProfessorDAOTest {
         dao.delete(professor);
         assertEquals(oldsize-1,dao.getAll().size());
     }
+
 }

--- a/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAOTest.java
+++ b/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAOTest.java
@@ -106,7 +106,7 @@ class ProfessorDAOTest {
         assertEquals( updatedProfessor, professor3);
     }
 
-    @Test//Not realy a test must be change when slot is implemented TODO
+    @Test
     void getProfessorOfASlot(){
         SlotDAO slotDAO = SlotDAO.getInstance();
 
@@ -135,8 +135,6 @@ class ProfessorDAOTest {
 
     @Test
     void addSameProfessor(){
-        final String defaultMsg = "Done Save Without Error";
-
         int oldSize = dao.getAll().size();
         dao.save(professor1, "testingOnly");
         int newSize = dao.getAll().size();

--- a/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAOTest.java
+++ b/edtLHD/src/test/java/fr/univtln/lhd/model/entities/dao/users/ProfessorDAOTest.java
@@ -1,13 +1,21 @@
 package fr.univtln.lhd.model.entities.dao.users;
 
 import fr.univtln.lhd.exceptions.IdException;
+import fr.univtln.lhd.model.entities.dao.slots.ClassroomDAO;
+import fr.univtln.lhd.model.entities.dao.slots.SlotDAO;
+import fr.univtln.lhd.model.entities.dao.slots.SubjectDAO;
+import fr.univtln.lhd.model.entities.slots.Classroom;
+import fr.univtln.lhd.model.entities.slots.Slot;
+import fr.univtln.lhd.model.entities.slots.Subject;
 import fr.univtln.lhd.model.entities.users.Professor;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.threeten.extra.Interval;
 
 import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,24 +23,59 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ProfessorDAOTest {
     public static final ProfessorDAO dao = ProfessorDAO.of();
 
-    private Professor getRandomNewProfessor(){
-        return Professor.of("UnitTest","UnitTestFirstName",
-                "UnitTestName.Firstname"+Math.random()+"@email.com","REseracher");
+    private Professor professor1;
+    private Professor professor2;
+
+    private Classroom classroom;
+    private Subject subject;
+
+    private Professor getRandomNewProfessor () {
+        return Professor.of("UnitTest", "UnitTestFirstName",
+                "UnitTestName.Firstname" + Math.random() + "@email.com", "REseracher");
     }
 
-    
-    private Professor getTheTestProfessor(){
-        return Professor.of("TheTestProfessor","UnitTestFirstName",
-                "UnitTestName.Firstname@email.com","Researcher");
+    @BeforeEach
+    public void initializeTestEnvironment () {
+        professor1 = Professor.of("name1", "fname1", "prof1TESTING@mail.com", "test");
+        professor2 = Professor.of("name2", "fname2", "prof2TESTING@mail.com", "test");
+        dao.save(professor1, "testingOnly");
+        dao.save(professor2, "testingOnly");
+    }
+
+    private void initSlotData () {
+        classroom = Classroom.getInstance("ClassroomTESTING");
+        subject = Subject.getInstance("SubjectTESTING", 100);
+
+        try {
+            ClassroomDAO.getInstance().save(classroom);
+            SubjectDAO.getInstance().save(subject);
+        } catch (SQLException e) {
+            throw new AssertionError();
+        }
+    }
+
+    @AfterEach
+    public void deleteTestEnvironment () {
+        dao.delete(professor1);
+        dao.delete(professor2);
+    }
+
+    private void deleteSlotData () {
+        try {
+            ClassroomDAO.getInstance().delete(classroom);
+            SubjectDAO.getInstance().delete(subject);
+        } catch (SQLException e) {
+            throw new AssertionError();
+        }
     }
 
     @Test
-    void CreateADAO(){
+    void CreateADAO () {
         Assertions.assertNotNull(dao);
     }
 
     @Test
-    void addNewProfessor(){
+    void addNewProfessor () {
         Professor professor = getRandomNewProfessor();
         int oldsize = dao.getAll().size();
         dao.save(professor,"1234");
@@ -43,11 +86,9 @@ class ProfessorDAOTest {
     @Test
     @Disabled("Causes the CI to fail")
     void getProfessorFromAuthTest(){
-        Professor professor = getTheTestProfessor();
-
         try {
-            Professor authGetterProfessor = dao.get(professor.getEmail(), "1234").orElse(null);
-            assertEquals(professor, authGetterProfessor);
+            Professor authGetterProfessor = dao.get(professor1.getEmail(), "testingOnly").orElse(null);
+            assertEquals(professor1, authGetterProfessor);
         }catch (SQLException e){
             log.error(e.getMessage());
             throw new AssertionError();
@@ -56,27 +97,49 @@ class ProfessorDAOTest {
 
     @Test
     void updateAprofessor() throws IdException {
-        Professor professor = getRandomNewProfessor();
-        Professor professor1 = Professor.of(professor.getName()+"1",professor.getFname()+"1",professor.getEmail()+"1", professor.getTitle());
-        dao.save(professor,"1234");
-        professor1.setId(professor.getId());
-        dao.update(professor1);
-        assertEquals(dao.get(professor.getId()).orElseThrow(AssertionError::new),professor1);
+        Professor professor3 = Professor.of(professor1.getName() + "1", professor1.getFname() + "1", professor1.getEmail() + "1", professor1.getTitle());
+        professor3.setId(professor1.getId());
+        dao.update(professor3);
+        Professor updatedProfessor = dao.get(professor3.getId()).orElseThrow(AssertionError::new);
+        assertEquals(updatedProfessor, professor3);
     }
 
     @Test//Not realy a test must be change when slot is implemented TODO
-    void getProfessorOfASlot(){
-        System.out.println(dao.getProfessorOfSlots(3));
-        assertEquals(2,1+1);
+    void getProfessorOfASlot() {
+        SlotDAO slotDAO = SlotDAO.getInstance();
+
+        initSlotData();
+
+        Slot slot = Slot.getInstance(
+                Slot.SlotType.TP,
+                classroom,
+                subject,
+                new ArrayList<>(),
+                List.of(professor1, professor2),
+                Interval.of(Instant.ofEpochSecond((long) (10000 + Math.random())), Instant.ofEpochSecond((long) (1000000 + Math.random())))
+        );
+
+        try {
+            slotDAO.save(slot);
+            List<Professor> professorsOfSlot = dao.getProfessorOfSlots(slot.getId());
+            assertEquals(professorsOfSlot, slot.getProfessors());
+            slotDAO.delete(slot);
+        } catch (SQLException e) {
+            throw new AssertionError();
+        }
+
+        deleteSlotData();
     }
 
     @Test
-    void addSameProfessor(){
-        Professor professor = getTheTestProfessor();
-        dao.save(professor,"1234");
-        int oldsize = dao.getAll().size();
-        dao.save(professor,"1234");
-        assertEquals(oldsize,dao.getAll().size());
+    void addSameProfessor() {
+        final String defaultMsg = "Done Save Without Error";
+
+        int oldSize = dao.getAll().size();
+        dao.save(professor1, "testingOnly");
+        int newSize = dao.getAll().size();
+
+        assertEquals(oldSize, newSize);
     }
 
 
@@ -88,5 +151,4 @@ class ProfessorDAOTest {
         dao.delete(professor);
         assertEquals(oldsize-1,dao.getAll().size());
     }
-
 }


### PR DESCRIPTION
the problem : 
Bunch of test are using data that is already stored in database, thus doing the test on database dependant content.

This fix should correct it, Test are now generating and saving into the database, every data needed to do the actual test, then delete it when finished, leaving the database untouched from outside pov.

(avoiding future problem for example if you run a sql script that erases needed id for testing purpose, now it's fine)